### PR TITLE
Fix #4, teach wb2k new tricks in the process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -20,9 +19,11 @@ lib64/
 parts/
 sdist/
 var/
+wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -42,7 +43,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-*,cover
+*.cover
 .hypothesis/
 
 # Translations
@@ -51,10 +52,16 @@ coverage.xml
 
 # Django stuff:
 *.log
+.static_storage/
+.media/
 local_settings.py
 
-# Flask instance folder
+# Flask stuff:
 instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
 
 # Sphinx documentation
 docs/_build/
@@ -62,12 +69,36 @@ docs/_build/
 # PyBuilder
 target/
 
-# IPython Notebook
+# Jupyter Notebook
 .ipynb_checkpoints
 
 # pyenv
 .python-version
 
-# dotenv
-.env
+# celery beat schedule file
+celerybeat-schedule
 
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+graft wb2k
+include *requirements.txt

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Those wishing to craft the highest quality welcome messages may eventually
 notice that putting `{user}` in your message causes it to replaced by a
 [user mention][user mention] for the user who just joined.
 
-![Magic!](https://i.imgur.com/iZcUNxH.gif)
+![Magic!](https://media0.giphy.com/media/12NUbkX6p4xOO4/giphy.gif)
 
 
 ### This Isn't What I Wanted

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `wb2k`
 
-Welcoming new folks to `#general` since `date --date='@1463824090'`.
+Welcoming new folks to `#general` since `date --date='@1463824090'` (except for
+that time between `1503469220` and `1506995527` when it was broken).
 
 ## What's in the Box?
 
@@ -69,6 +70,26 @@ Do keep in mind that `wb2k` actually has to have access to
 `#some_random_channel`. You can't just use it to snoop on previously
 unknown or private channels.
 
+### I Don't Like Your Welcome Message!
+_Chill_. The `-m` flag was added just for you (yes, you)! Feel free to
+customize messages until the cows come home.
+```shell
+wb2k -m 'ようこそ!'
+```
+
+As is customary, you can define a `WB2K_MESSAGE` environment variable like
+```
+export WB2K_MESSAGE="Look, newlines
+and basic :slack: formatting are supported as well!"
+```
+
+Those wishing to craft the highest quality welcome messages may eventually
+notice that putting `{user}` in your message causes it to replaced by a
+[user mention][user mention] for the user who just joined.
+
+![Magic!](https://i.imgur.com/iZcUNxH.gif)
+
+
 ### This Isn't What I Wanted
 
 Still confused? Consult
@@ -84,3 +105,4 @@ This package was created with help from [Cookiecutter].
 [create a new bot]: https://my.slack.com/services/new/bot
 [virtualenv]: https://virtualenv.pypa.io/en/stable
 [Cookiecutter]: https://github.com/audreyr/cookiecutter
+[user mention]: https://get.slack.help/hc/en-us/articles/205240127-Mention-a-member

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+# TODO: Put package development requirements here.
+-r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-click==6.6
-requests==2.10.0
-six==1.10.0
-slackclient==1.0.0
-websocket-client==0.37.0
+click==6.7
+slackclient==1.0.9
+websocket-client==0.44.0

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 import re
 import os.path
+import sys
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
 
+if sys.version_info < (3, 6):
+    sys.exit('Python 3.6+ is required. Ancient Python is unsupported.')
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -44,6 +47,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Operating System :: POSIX :: BSD :: FreeBSD',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
     ],
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import re
 import os.path
 from setuptools import setup, find_packages
+from pip.req import parse_requirements
 
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -16,14 +17,8 @@ with open(version_path, 'r') as version_file:
     version = re.compile(r".*__version__ = '(.*?)'",
                          re.S).match(version_file.read()).group(1)
 
-requirements = [
-    'click',
-    'slackclient'
-]
-
-test_requirements = [
-    # TODO: put package test requirements here
-]
+install_reqs = [str(r.req) for r in parse_requirements('requirements.txt', session=False)]
+test_reqs = [str(r.req) for r in parse_requirements('dev-requirements.txt', session=False)]
 
 setup(
     name='wb2k',
@@ -36,7 +31,7 @@ setup(
     packages=find_packages(),
     package_dir={'wb2k': 'wb2k'},
     include_package_data=True,
-    install_requires=requirements,
+    install_requires=install_reqs,
     license='ISCL',
     zip_safe=False,
     py_modules=['wb2k'],
@@ -52,7 +47,10 @@ setup(
         'Programming Language :: Python :: 3 :: Only',
     ],
     test_suite='tests',
-    tests_require=test_requirements,
+    tests_require=test_reqs,
+    extras_require={
+        'dev': test_reqs,
+    },
     entry_points={
         'console_scripts': [
             'wb2k=wb2k.__main__:cli',

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -10,7 +10,7 @@ from slackclient import SlackClient
 
 
 def bail(msg_type: str, color: str, text: str) -> str:
-    return "{}: {}".format(click.style(msg_type, fg=color), text)
+    return f"{click.style(msg_type, fg=color)}: {text}"
 
 
 def setup_logging(verbose: int) -> None:
@@ -54,7 +54,7 @@ def find_channel_id(channel: str, sc: SlackClient) -> str:
     channel_ids = [c['id'] for c in channels_list + groups_list if c['name'] == channel]
 
     if not channel_ids:
-        sys.exit(bail('fatal', 'red', "Couldn't find #{}".format(channel)))
+        sys.exit(bail('fatal', 'red', f"Couldn't find #{channel}"))
 
     return channel_ids[0]
 
@@ -74,12 +74,11 @@ def handle_message(message: str, channel: str, channel_id: str, sc: SlackClient,
 
         if message_channel_id == channel_id:
             try:
-                sc.rtm_send_message(channel,
-                                    "Welcome, <@{}>! :hand:".format(user))
-                logger.info("Welcomed {} to #{}".format(username, channel))
+                sc.rtm_send_message(channel, f"Welcome, <@{user}>! :hand:")
+                logger.info(f"Welcomed {username} to #{channel}")
             except AttributeError:
                 logger.setLevel(logging.ERROR)
-                logger.error("Couldn't send message to #{}".format(channel))
+                logger.error(f"Couldn't send message to #{channel}")
 
 
 @click.command()
@@ -110,9 +109,9 @@ def cli(channel: str, verbose: int, retries: int) -> None:
         logger.info("Connected to Slack")
 
         channel_id = find_channel_id(channel, sc)
-        logger.debug("Found channel ID {} for #{}".format(channel_id, channel))
+        logger.debug(f"Found channel ID {channel_id} for #{channel}")
 
-        logger.info("Listening for joins in #{}".format(channel))
+        logger.info(f"Listening for joins in #{channel}")
 
         retry_count = 0
         backoff = 0.5

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -102,6 +102,9 @@ def handle_event(event: dict, channel: str, channel_id: str, message: str,
               help='The maximum number of times to attempt to reconnect on websocket connection errors')
 @click.version_option()
 def cli(channel: str, message: str, verbose: int, retries: int) -> None:
+    # Due to some unfortunate limitations in the Slack RTM API
+    # (https://api.slack.com/rtm#formatting_messages) message formatting is
+    # limited to basic formatting.
 
     if verbose > 11:
         sys.exit(bail('fatal', 'red', "It doesn't go beyond 11"))

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -3,6 +3,7 @@ import sys
 import time
 import logging
 import logging.config
+from pprint import pformat
 
 import click
 import websocket  # Depedency of slackclient, needed for exception handling
@@ -61,7 +62,8 @@ def find_channel_id(channel: str, sc: SlackClient) -> str:
 
 def handle_message(message: str, channel: str, channel_id: str, sc: SlackClient,
                    logger: logging.Logger) -> None:
-    logger.debug(message)
+    pretty_message = pformat(message)
+    logger.debug(f"New message received:\n{pretty_message}")
 
     subtype = message.get('subtype')
     user = message.get('user')

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -128,10 +128,14 @@ def cli(channel, verbose, retries):
 
                 time.sleep(0.5)
 
-            # The websocket module is not an explicit depedency of wb2k, but is
-            # necessary to handle an error caused by a bug in Slack's python
-            # client: https://github.com/slackhq/python-slackclient/issues/127
-            except websocket.WebSocketConnectionClosedException:
+            # This is necessary to handle an error caused by a bug in Slack's
+            # Python client. For more information see
+            # https://github.com/slackhq/python-slackclient/issues/127
+            #
+            # The TimeoutError could be more elegantly resolved by making a PR
+            # to the websocket-client library and letting them coerce that
+            # exception to a WebSocketTimeoutException.
+            except (websocket.WebSocketConnectionClosedException, TimeoutError):
                 logger.error("Lost connection to Slack, reconnecting...")
                 if not sc.rtm_connect():
                     logger.info("Failed to reconnect to Slack")

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -70,13 +70,16 @@ def handle_message(message: str, channel: str, channel_id: str, sc: SlackClient,
 
     if subtype in ('group_join', 'channel_join') and user:
 
+        # We will use the message's channel ID to send a response and refer to
+        # users by their display_name in accordance with new guidelines.
+        # https://api.slack.com/changelog/2017-09-the-one-about-usernames
         message_channel_id = message.get('channel')
         user_profile = message.get('user_profile')
-        username = user_profile.get('name')
+        username = user_profile.get('display_name')
 
         if message_channel_id == channel_id:
             try:
-                sc.rtm_send_message(channel, f"Welcome, <@{user}>! :wave:")
+                sc.rtm_send_message(message_channel_id, f"Welcome, <@{user}>! :wave:")
                 logger.info(f"Welcomed {username} to #{channel}")
             except AttributeError:
                 logger.setLevel(logging.ERROR)

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -74,7 +74,7 @@ def handle_message(message: str, channel: str, channel_id: str, sc: SlackClient,
 
         if message_channel_id == channel_id:
             try:
-                sc.rtm_send_message(channel, f"Welcome, <@{user}>! :hand:")
+                sc.rtm_send_message(channel, f"Welcome, <@{user}>! :wave:")
                 logger.info(f"Welcomed {username} to #{channel}")
             except AttributeError:
                 logger.setLevel(logging.ERROR)

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -9,11 +9,11 @@ import websocket  # Depedency of slackclient, needed for exception handling
 from slackclient import SlackClient
 
 
-def bail(msg_type, color, text):
+def bail(msg_type: str, color: str, text: str) -> str:
     return "{}: {}".format(click.style(msg_type, fg=color), text)
 
 
-def setup_logging(verbose):
+def setup_logging(verbose: int) -> None:
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,
@@ -43,7 +43,7 @@ def setup_logging(verbose):
     })
 
 
-def find_channel_id(channel, sc):
+def find_channel_id(channel: str, sc: SlackClient) -> str:
     channels_list = sc.api_call("channels.list").get('channels')
     groups_list = sc.api_call("groups.list").get('groups')
 
@@ -59,7 +59,8 @@ def find_channel_id(channel, sc):
     return channel_ids[0]
 
 
-def handle_message(message, channel, channel_id, sc, logger):
+def handle_message(message: str, channel: str, channel_id: str, sc: SlackClient,
+                   logger: logging.Logger) -> None:
     logger.debug(message)
 
     subtype = message.get('subtype')
@@ -89,7 +90,7 @@ def handle_message(message, channel, channel_id, sc, logger):
 @click.option('-r', '--retries', envvar='WB2K_RETRIES', default=8, type=(int), metavar='max_retries',
               help='The maximum number of times to attempt to reconnect on websocket connection errors')
 @click.version_option()
-def cli(channel, verbose, retries):
+def cli(channel: str, verbose: int, retries: int) -> None:
 
     if verbose > 11:
         sys.exit(bail('fatal', 'red', "It doesn't go beyond 11"))


### PR DESCRIPTION
This PR puts a band-aid on #4 by lazily catching the `TimeoutError` and attempting the retry logic.

It also takes advantage of some new Python 3 features (namely [f-strings](https://www.python.org/dev/peps/pep-0498/) and [type hinting](https://www.python.org/dev/peps/pep-0484/)) and adds a `--message` option for customizing the welcome message.

This will make `wb2k` Python 3.6+ only, so that obviously makes it superior, right?