### PR TITLE
Remove extraneous logger.setLevel. Fixes #2

### DIFF
--- a/tests/test_wb2k.py
+++ b/tests/test_wb2k.py
@@ -199,5 +199,4 @@ def test_handle_event_unable_to_send_response(slack_client, monkeypatch):
         logger=logger
     )
 
-    logger.setLevel.assert_called_once_with(logging.ERROR)
     logger.error.assert_called_once_with(f"Couldn't send message to #{channel}")

--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -84,7 +84,6 @@ def handle_event(event: dict, channel: str, channel_id: str, message: str,
                 sc.rtm_send_message(event_channel_id, message)
                 logger.info(f"Welcomed {username} to #{channel}")
             except AttributeError:
-                logger.setLevel(logging.ERROR)
                 logger.error(f"Couldn't send message to #{channel}")
 
 


### PR DESCRIPTION
TFW you remove lines, the test coverage remains exactly the same, and you get to close an issue.

![tfw-code-removed](https://user-images.githubusercontent.com/3084059/34810891-b348b95e-f652-11e7-9fe6-e96463d5f0f5.gif)
