### PR TITLE
Extract core logic from cli function into run function

### DIFF
--- a/wb2k/__main__.py
+++ b/wb2k/__main__.py
@@ -87,38 +87,8 @@ def handle_event(event: dict, channel: str, channel_id: str, message: str,
                 logger.error(f"Couldn't send message to #{channel}")
 
 
-@click.command()
-@click.option('-c', '--channel', envvar='WB2K_CHANNEL', default='general',
-              show_default=True, metavar='CHANNEL',
-              help='The channel to welcome users to.')
-@click.option('-m', '--message', envvar='WB2K_MESSAGE',
-              default='Welcome, {user}! :wave:', show_default=True,
-              metavar='MESSAGE',
-              help='The message to use when welcoming users. If present {user} '
-              'will be replaced by a user mention.')
-@click.option('-v', '--verbose', count=True, help='It goes to 11.')
-@click.option('-r', '--retries', envvar='WB2K_RETRIES', default=8, type=(int), metavar='max_retries',
-              help='The maximum number of times to attempt to reconnect on websocket connection errors')
-@click.version_option()
-def cli(channel: str, message: str, verbose: int, retries: int) -> None:
-    # Due to some unfortunate limitations in the Slack RTM API
-    # (https://api.slack.com/rtm#formatting_messages) message formatting is
-    # limited to basic formatting.
-
-    if verbose > 11:
-        sys.exit(bail('fatal', 'red', "It doesn't go beyond 11"))
-
-    # Get our logging in order.
-    logger = logging.getLogger(__name__)
-    setup_logging(verbose)
-
-    # Make sure we have an API token.
-    api_token = os.environ.get('WB2K_TOKEN')
-    if not api_token:
-        sys.exit(bail('fatal', 'red', 'WB2K_TOKEN envvar undefined'))
-
-    # Instantiate and connect!
-    sc = SlackClient(api_token)
+def run(sc: SlackClient, channel: str, message: str, retries: int,
+        logger: logging.Logger) -> None:
     if sc.rtm_connect():
         logger.info("Connected to Slack")
 
@@ -167,6 +137,47 @@ def cli(channel: str, message: str, verbose: int, retries: int) -> None:
 
     else:
         sys.exit(bail('fatal', 'red', "Couldn't connect to Slack"))
+
+
+@click.command()
+@click.option('-c', '--channel', envvar='WB2K_CHANNEL', default='general',
+              show_default=True, metavar='CHANNEL',
+              help='The channel to welcome users to.')
+@click.option('-m', '--message', envvar='WB2K_MESSAGE',
+              default='Welcome, {user}! :wave:', show_default=True,
+              metavar='MESSAGE',
+              help='The message to use when welcoming users. If present {user} '
+              'will be replaced by a user mention.')
+@click.option('-v', '--verbose', count=True, help='It goes to 11.')
+@click.option('-r', '--retries', envvar='WB2K_RETRIES', default=8, type=(int), metavar='max_retries',
+              help='The maximum number of times to attempt to reconnect on websocket connection errors')
+@click.version_option()
+def cli(channel: str, message: str, verbose: int, retries: int) -> None:
+    # Due to some unfortunate limitations in the Slack RTM API
+    # (https://api.slack.com/rtm#formatting_messages) message formatting is
+    # limited to basic formatting.
+
+    if verbose > 11:
+        sys.exit(bail('fatal', 'red', "It doesn't go beyond 11"))
+
+    # Get our logging in order.
+    logger = logging.getLogger(__name__)
+    setup_logging(verbose)
+
+    # Make sure we have an API token.
+    api_token = os.environ.get('WB2K_TOKEN')
+    if not api_token:
+        sys.exit(bail('fatal', 'red', 'WB2K_TOKEN envvar undefined'))
+
+    sc = SlackClient(api_token)
+
+    run(
+        sc=sc,
+        channel=channel,
+        message=message,
+        retries=retries,
+        logger=logger
+    )
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
This allows the CLI to be a thinner wrapper around the core `wb2k` functionality. The main logic is now moved into the `run` function so that it can be more easily tested and extended without interfering with the CLI code.